### PR TITLE
Updates to Config utils to compare slices and adding tags to networking config structs

### DIFF
--- a/configUtils.go
+++ b/configUtils.go
@@ -106,8 +106,8 @@ func (a *ConfigAnalyzer) callGroupChanges(c *changes) {
 			}
 			takeall := hook.ChangesComplete(c.configgroup)
 			if takeall {
-				for n, cur := range c.curvals {
-					c.curvals[n].Set(cur)
+				for n := range c.curvals {
+					c.curvals[n].Set(c.futvals[n])
 				}
 			}
 		}

--- a/configUtils_test.go
+++ b/configUtils_test.go
@@ -95,7 +95,7 @@ func TestMain(m *testing.M) {
 
 type testHook struct {
 	a func(g string)
-	b func(g string, f string, v interface{}, v2 interface{}) bool
+	b func(g string, f string, v interface{}, v2 interface{}, index int) bool
 	c func(g string) bool
 }
 
@@ -105,9 +105,9 @@ func (hook *testHook) ChangesStart(g string) {
 	}
 }
 
-func (hook *testHook) SawChange(g string, field string, curv interface{}, futv interface{}) (ret bool) {
+func (hook *testHook) SawChange(g string, field string, curv interface{}, futv interface{}, index int) (ret bool) {
 	if hook.b != nil {
-		ret = hook.b(g, field, curv, futv)
+		ret = hook.b(g, field, curv, futv, index)
 	}
 	return
 }
@@ -123,7 +123,7 @@ func (hook *testHook) OnChangesStart(p func(string)) {
 	hook.a = p
 }
 
-func (hook *testHook) OnSawChange(p func(g string, field string, curv interface{}, futv interface{}) bool) {
+func (hook *testHook) OnSawChange(p func(g string, field string, curv interface{}, futv interface{}, index int) bool) {
 	hook.b = p
 }
 
@@ -160,7 +160,7 @@ func TestBasicConf1(t *testing.T) {
 		log.Fatal("Shold not be called - no change here")
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		changesN++
 		return true
@@ -175,7 +175,7 @@ func TestBasicConf1(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		changesN++
 		return true
@@ -246,7 +246,7 @@ func TestBasicConf1Ptr(t *testing.T) {
 		log.Fatal("Shold not be called - no change here")
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -262,7 +262,7 @@ func TestBasicConf1Ptr(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -332,7 +332,7 @@ func TestDeeperConf1Ptr(t *testing.T) {
 		startsN++
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -348,7 +348,7 @@ func TestDeeperConf1Ptr(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -423,7 +423,7 @@ func TestDeeperConf2Ptr(t *testing.T) {
 		startsN++
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -440,7 +440,7 @@ func TestDeeperConf2Ptr(t *testing.T) {
 		startsN++
 	})
 
-	hookStuff.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookStuff.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookStuff: %s\n", g, field)
 		changesN++
@@ -455,7 +455,7 @@ func TestDeeperConf2Ptr(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -544,7 +544,7 @@ func TestNonCongruentStructs(t *testing.T) {
 		log.Fatal("Shold not be called - no change here")
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -560,7 +560,7 @@ func TestNonCongruentStructs(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -629,7 +629,7 @@ func TestFillInNilStruct(t *testing.T) {
 		log.Fatal("Shold not be called - no change here")
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -645,7 +645,7 @@ func TestFillInNilStruct(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -661,7 +661,7 @@ func TestFillInNilStruct(t *testing.T) {
 		startsN++
 	})
 
-	hookWiz.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookWiz.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookWiz: %s\n", g, field)
 		v, ok := futv.(int)
@@ -752,7 +752,7 @@ func TestTakeAllChanges(t *testing.T) {
 		log.Fatal("Shold not be called - no change here")
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -768,7 +768,7 @@ func TestTakeAllChanges(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -789,7 +789,7 @@ func TestTakeAllChanges(t *testing.T) {
 		startsN++
 	})
 
-	hookWiz.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookWiz.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookWiz: %s\n", g, field)
 		v, ok := futv.(int)
@@ -877,6 +877,7 @@ func TestFillInWithSlice(t *testing.T) {
 
 	changesN := 0
 	startsN := 0
+	indexFailed := false
 
 	hookMagic := new(testHook)
 
@@ -885,7 +886,7 @@ func TestFillInWithSlice(t *testing.T) {
 		log.Fatal("Shold not be called - no change here")
 	})
 
-	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookMagic.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookMagic: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookMagic: %s\n", g, field)
 		changesN++
@@ -901,7 +902,7 @@ func TestFillInWithSlice(t *testing.T) {
 		startsN++
 	})
 
-	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookDum.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookDum: %s\n", g, field)
 		changesN++
@@ -917,7 +918,7 @@ func TestFillInWithSlice(t *testing.T) {
 		startsN++
 	})
 
-	hookWiz.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookWiz.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookWiz: %s\n", g, field)
 		v, ok := futv.(int)
@@ -941,7 +942,7 @@ func TestFillInWithSlice(t *testing.T) {
 		//		startsN++
 	})
 
-	hookFood.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookFood.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
 		fmt.Printf("SawChange( %s ) hookFood: %s\n", g, field)
 		//		changesN++
@@ -957,10 +958,20 @@ func TestFillInWithSlice(t *testing.T) {
 		//		startsN++
 	})
 
-	hookFoodItem.OnSawChange(func(g string, field string, futv interface{}, curv interface{}) bool {
+	hookFoodItem.OnSawChange(func(g string, field string, futv interface{}, curv interface{}, index int) bool {
 		//		fmt.Printf("SawChange( %s ) hookDum: %s: %+v --> %+v\n", g, field, curv, futv)
-		fmt.Printf("SawChange( %s ) hookFoodItem: %s\n", g, field)
+		fmt.Printf("SawChange( %s ) hookFoodItem: %s futval:%s index:%d\n", g, field, futv, index)
 		//		changesN++
+		if(futv == "apples") {
+			if(index != 0) {
+				indexFailed = true;
+			}
+		}
+		if(futv == "oranges") {
+			if(index != 1) {
+				indexFailed = true;
+			}
+		}
 		return true
 	})
 
@@ -994,6 +1005,12 @@ func TestFillInWithSlice(t *testing.T) {
 	s2.Stuff.NumberOfPotions = 7
 
 	same, noaction, err := a.CallChanges(s1, s2)
+
+	if indexFailed {
+		log.Fatal("Error from OnSawChange, index value mismatch")
+	} else {
+		fmt.Printf("indexFailed %+v\n", indexFailed)
+	}
 
 	if err != nil {
 		log.Fatal("Error from CallOnChanges:", err.Error())

--- a/networking.go
+++ b/networking.go
@@ -27,11 +27,11 @@ type IEEE8021x struct {
 
 type AliasAddressV4 struct {
 	// IPv4 Address
-	IPv4Addr string `yaml:"ipv4_addr" json:"ipv4_addr"`
+	IPv4Addr string `yaml:"ipv4_addr" json:"ipv4_addr" netgroup:"ipv4"`
 	// IPv4 Subnet Mask
-	IPv4Mask string `yaml:"ipv4_mask" json:"ipv4_mask"`
+	IPv4Mask string `yaml:"ipv4_mask" json:"ipv4_mask" netgroup:"ipv4"`
 	// IPv4 Broadcast Addr. If empty, set automatically
-	IPv4BCast string `yaml:"ipv4_bcast" json:"ipv4_bcast"`
+	IPv4BCast string `yaml:"ipv4_bcast" json:"ipv4_bcast" netgroup:"ipv4"`
 }
 
 const (
@@ -41,23 +41,23 @@ const (
 
 type NetIfConfigPayload struct {
 	// like "eth0"
-	IfName string `yaml:"if_name" json:"if_name"`
+	IfName string `yaml:"if_name" json:"if_name" netgroup:"if"`
 	// use either this or IfName, index is a non-zero positive integer
 	// IfName is preferred and takes precedence
-	IfIndex int `yaml:"if_index" json:"if_index"`
+	IfIndex int `yaml:"if_index" json:"if_index" netgroup:"if"`
 	// use DHCP?
-	DhcpV4Enabled bool `yaml:"dhcpv4" json:"dhcpv4"`
+	DhcpV4Enabled bool `yaml:"dhcpv4" json:"dhcpv4" netgroup:"ipv4"`
 	// IPv4 Address
-	IPv4Addr string `yaml:"ipv4_addr" json:"ipv4_addr"`
+	IPv4Addr string `yaml:"ipv4_addr" json:"ipv4_addr" netgroup:"ipv4"`
 	// IPv4 Subnet Mask  - of the CIDR form, such as in 192.168.1.21/24
 	// then this number would be 24
-	IPv4Mask int `yaml:"ipv4_mask" json:"ipv4_mask"`
+	IPv4Mask int `yaml:"ipv4_mask" json:"ipv4_mask" netgroup:"ipv4"`
 	// IPv4 Broadcast Addr. If empty, set automatically
-	IPv4BCast string `yaml:"ipv4_bcast" json:"ipv4_bcast"`
+	IPv4BCast string `yaml:"ipv4_bcast" json:"ipv4_bcast" netgroup:"ipv4"`
 	// additional addresses to assign to the interface, if any
-	AliasAddrV4 []AliasAddressV4 `yaml:"alias_ipv4" json:"alias_ipv4"`
+	AliasAddrV4 []AliasAddressV4 `yaml:"alias_ipv4" json:"alias_ipv4" netgroup:"ipv4"`
 	// IPv6 Address
-	IPv6Addr string `yaml:"ipv6_addr" json:"ipv6_addr"`
+	IPv6Addr string `yaml:"ipv6_addr" json:"ipv6_addr"  netgroup:"ipv6"`
 	// // IPv4 Subnet Mask
 	// IPv6Mask string `yaml:"ipv4_mask" json:"ipv4_mask"`
 
@@ -65,62 +65,62 @@ type NetIfConfigPayload struct {
 	// MAC addresses should be formatted "aa:bb:cc:01:23:45" etc.
 	// 48 or 64 bit addresses can be stated, or whatever may be supported by the hardware
 	// such as a 20-octet IP for InifiniBand
-	HwAddr string `yaml:"hw_addr" json:"hw_addr"`
+	HwAddr string `yaml:"hw_addr" json:"hw_addr" netgroup:"mac"`
 
 	// WiFi settings, if any
-	WiFiSettings *WiFiSettings `yaml:"wifi" json:"wifi"`
+	WiFiSettings *WiFiSettings `yaml:"wifi" json:"wifi" netgroup:"wifi"`
 
 	// IEEE8021x is the IEEE 802.1x auth settings
-	IEEE8021x *IEEE8021x `yaml:"ieee8021x" json:"ieee8021x"`
+	IEEE8021x *IEEE8021x `yaml:"ieee8021x" json:"ieee8021x" netgroup:"IEEE8021x"`
 
 	// These typically optional:
 	// if not empty, this address will be deleted before setting the new address
-	ReplaceAddress string `yaml:"replace_addr" json:"replace_addr"`
+	ReplaceAddress string `yaml:"replace_addr" json:"replace_addr" netgroup:"mac"`
 	// if true, this will clear any existing addresses assigned to the interface
 	// before setting up the specified addresses
-	ClearAddresses bool `yaml:"clear_addresses" json:"clear_addresses"`
+	ClearAddresses bool `yaml:"clear_addresses" json:"clear_addresses" netgroup:"mac"`
 	// if true, the interface should be configured, be turned off / disabled (rare)
-	Down bool `yaml:"down" json:"down"`
+	Down bool `yaml:"down" json:"down" group:"mac"`
 
 	// DefaultGateway is a default route associated with this interface, which should be set if this
 	// interface is up. If empty, none will be setup - unless DHCP provides one. If one is provided
 	// here it will override the DHCP provided one. The Priority field
 	// should help determine which route has the best metric, which will allow the kernel
 	// to use the fastest route.
-	DefaultGateway string `yaml:"default_gateway" json:"default_gateway"`
+	DefaultGateway string `yaml:"default_gateway" json:"default_gateway"  netgroup:"gateway"`
 
 	// NOT IMPLEMENTED
-	FallbackDefaultGateway string `yaml:"fallback_default_gateway" json:"fallback_default_gateway"`
+	FallbackDefaultGateway string `yaml:"fallback_default_gateway" json:"fallback_default_gateway" netgroup:"gateway"`
 
 	// RoutePriority. Priority 0 - means the first, primary interface, 1 would mean
 	// the secondary, etc. Priority is used to decide which physical interface should
 	// be the default route, if such interface has a default GW
 	// valid values: 0-9 (MaxRoutePriority)
-	RoutePriority int `yaml:"route_priority" json:"route_priority"`
+	RoutePriority int `yaml:"route_priority" json:"route_priority" netgroup:"route"`
 
 	// An Aux interface, is not considered in the line up of outbound interfaces
 	// It usually routes to an internal only network
-	Aux bool `yaml:"aux" json:"aux"`
+	Aux bool `yaml:"aux" json:"aux"  netgroup:"mac"`
 
 	// NOT IMPLEMENTED
 	// Override DNS
 	// Use only on a secondary, backup interface. If the interface becomes active
 	// then DNS should switch to this server.
-	NameserverOverrides string `yaml:"nameserver_overrides" json:"nameserver_overrides"`
+	NameserverOverrides string `yaml:"nameserver_overrides" json:"nameserver_overrides" netgroup:"nameserver"`
 
 	// NOT IMPLEMENTED
 	// routes this interfaces provides
-	Routes []string `yaml:"routes" json:"routes"`
+	Routes []string `yaml:"routes" json:"routes" netgroup:"route"`
 
 	// NOT IMPLEMENTED
 	// A https test server to use for this interface, to make sure
 	// the interface has a route out. If empty, ignored
-	TestHttpsRouteOut string `yaml:"test_https_route_out" json:"test_https_route_out"`
+	TestHttpsRouteOut string `yaml:"test_https_route_out" json:"test_https_route_out" netgroup:"http"`
 
 	// NOT IMPLEMENTED
 	// A host to ICMPv4 echo, to test that this interface has
 	// a route to where it should. If empty, ignored
-	TestICMPv4EchoOut string `yaml:"test_echo_route_out" json:"test_echo_route_out"`
+	TestICMPv4EchoOut string `yaml:"test_echo_route_out" json:"test_echo_route_out" netgroup:"ipv4"`
 
 	// DHCP specific options:
 
@@ -129,11 +129,11 @@ type NetIfConfigPayload struct {
 	// provided by the DHCP server. This disables that behavior,
 	// meaning existing addresses will remain on the interface - if they were there
 	// before Maestro started.
-	DhcpDisableClearAddresses bool `yaml:"dhcp_disable_clear_addresses" json:"dhcp_disable_clear_addresses"`
+	DhcpDisableClearAddresses bool `yaml:"dhcp_disable_clear_addresses" json:"dhcp_disable_clear_addresses" netgroup:"dhcp"`
 
 	// DhcpStepTimeout is the maximum amount of seconds to wait in each step
 	// of getting a DHCP address. If not set, a sane default will be used.
-	DhcpStepTimeout int `yaml:"dhcp_step_timeout" json:"dhcp_step_timeout"`
+	DhcpStepTimeout int `yaml:"dhcp_step_timeout" json:"dhcp_step_timeout"  netgroup:"dhcp"`
 
 	// For use typically in the config file, not required. For incoming API calls,
 	// the default behavior is "override", b/c the API calls always modify the
@@ -142,7 +142,7 @@ type NetIfConfigPayload struct {
 	// existing: ""          # this is the default. The database will take precedence, if it has an entry for the interface
 	// existing: "replace"   # this will remove the existing datavase entry entirely. And then take whatever
 	//                       # the config file has to offer
-	Existing string `yaml:"existing" json:"existing"`
+	Existing string `yaml:"existing" json:"existing" netgroup:"config_netif"`
 }
 
 // type Nameserver struct {
@@ -151,48 +151,48 @@ type NetIfConfigPayload struct {
 
 type NetworkConfigPayload struct {
 	// an array of network interfaces to configure
-	Interfaces []*NetIfConfigPayload `yaml:"interfaces" json:"interfaces"`
+	Interfaces []*NetIfConfigPayload `yaml:"interfaces" json:"interfaces" netgroup:"if"`
 
 	// DontOverrideDefaultRoute when true means maestro will not
 	// replace the default route, if one exists, with a setting from the interface
 	// whether via DHCP or static. If a route is not in place, or the route was set by
 	// maestro, it will replace this route.
-	DontOverrideDefaultRoute bool `yaml:"dont_override_default_route" json:"dont_override_default_route"`
+	DontOverrideDefaultRoute bool `yaml:"dont_override_default_route" json:"dont_override_default_route" netgroup:"route"`
 
-	Nameservers []string `yaml:"nameservers" json:"nameservers"`
+	Nameservers []string `yaml:"nameservers" json:"nameservers" netgroup:"nameserver"`
 
 	// this tells network subsystem to ignore DHCP offers which have
 	// DNS server settings. Whatever the DHCP server says in regards to
 	// DNS will be ignored
-	DnsIgnoreDhcp bool `yaml:"dns_ignore_dhcp" json:"dns_ignore_dhcp"`
+	DnsIgnoreDhcp bool `yaml:"dns_ignore_dhcp" json:"dns_ignore_dhcp" netgroup:"dns"`
 
 	// AltResolvConf, if populated with a string, will cause the network subsystem to
 	// not write /etc/resolv.conf, and instead write what would go to /etc/resolv.conf to
 	// an alternate file.
-	AltResolvConf string `yaml:"alt_resolv_conf" json:"alt_resolve_conf"`
+	AltResolvConf string `yaml:"alt_resolv_conf" json:"alt_resolve_conf" netgroup:"nameserver"`
 
 	// if any of the below are true, then Nameserver shoul be set to
 	// 127.0.0.1
 
 	// DnsRunLocalCaching if true, a local caching nameserver will be used.
-	DnsRunLocalCaching bool `yaml:"dns_local_caching" json:"dns_local_caching"`
+	DnsRunLocalCaching bool `yaml:"dns_local_caching" json:"dns_local_caching" netgroup:"dns"`
 
 	// True if the gateway should forward all DNS requests to a
 	// specific gateway only
-	DnsForwardTo string `yaml:"default_gateway" json:"default_gateway"`
+	DnsForwardTo string `yaml:"default_gateway" json:"default_gateway" netgroup:"dns"`
 
 	// True if you want the gateway to do lookup via DNS root servers
 	// i.e. the gateway runs it's own recursive, lookup name server
-	DnsRunRootLookup bool `yaml:"dns_root_lookup" json:"dns_root_lookup"`
+	DnsRunRootLookup bool `yaml:"dns_root_lookup" json:"dns_root_lookup" netgroup:"dns"`
 
 	// A string, which is what the content of the /etc/hosts file should
 	// be
-	DnsHostsData string `yaml:"dns_hosts_data" json:"dns_hosts_data"`
+	DnsHostsData string `yaml:"dns_hosts_data" json:"dns_hosts_data" netgroup:"dns"`
 
 	// Fallback Gateways. (NOT IMPLEMENTED)
 	// These will be enabled if a primary outbound interface fails,
 	// and a secondary outbound interface exists
-	FallbackNameservers string `yaml:"fallback_nameservers" json:"fallback_nameservers"`
+	FallbackNameservers string `yaml:"fallback_nameservers" json:"fallback_nameservers" netgroup:"nameserver"`
 
 	// For use typically in the config file, not required. For incoming API calls,
 	// the default behavior is "override", b/c the API calls always modify the
@@ -201,7 +201,7 @@ type NetworkConfigPayload struct {
 	// existing: ""          # this is the default. The database will take precedence, if it has an entry for the interface
 	// existing: "replace"   # this will remove the existing database entry entirely. And then take whatever
 	//                       # the config file has to offer
-	Existing string `yaml:"existing" json:"existing"`
+	Existing string `yaml:"existing" json:"existing" netgroup:"config_network"`
 }
 
 const OP_TYPE_NET_INTERFACE = "net_interface"


### PR DESCRIPTION
This PR contains changes from @edhemphill to implement support in Config Utils to detect delta in  golang "slices" and corresponding tests. In addition I have changes to add tags to networking config structs and additions to configUtils to split the CallChanges into Diff and CallChanges. All the tests are passing with these changes and should be ok to merge.