### PR TITLE
add greaseAssign specifier to LogTarget.Name

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -55,7 +55,7 @@ type LogTarget struct {
 	FormatOrigin             string                           `yaml:"format_origin,omitempty" greaseAssign:"Format_origin"`
 	FormatPost               string                           `yaml:"format_post,omitempty" greaseAssign:"Format_post"`
 	FormatPreMsg             string                           `yaml:"format_pre_msg,omitempty" greaseAssign:"Format_pre_msg"`
-	Name                     string                           `yaml:"name,omitempty"`
+	Name                     string                           `yaml:"name,omitempty" greaseAssign:"Name"`
 	Flag_json_escape_strings bool                             `yaml:"flag_json_escape_strings"`
 }
 


### PR DESCRIPTION
the greaseAssign specifier causes the field to be copied
from the LogTarget struct into a grease specific struct when
sending config data from maestro into libgrease.

we need this because we want to pass the LogTarget.Name down
to greasego so that it can be cached for later lookup.